### PR TITLE
Remove lodash dependency. Use Array.isArray

### DIFF
--- a/firebase-key-encode.js
+++ b/firebase-key-encode.js
@@ -1,5 +1,3 @@
-var _ = require('lodash');
-
 module.exports = {
     encode: function (decoded) {
         return encodeURIComponent(decoded).replace(/\./g, '%2E');
@@ -10,21 +8,21 @@ module.exports = {
     // Replaces the key with `fn(key)` on each key in an object tree.
     // i.e. making all keys uppercase.
     deepKeyReplace: function (obj, fn) {
-        var rebuiltTree = _.clone(obj);
+        var rebuiltTree = Object.assign({}, obj);
 
         function traverse(o, x, func) {
             if (typeof(o) === "object") {
                 for (var i in o) {
-                    if (o[i] !== null && (typeof(o[i])=="object" || typeof(o[i])=="array")) {
+                    if (o[i] !== null && (typeof(o[i])=="object" || Array.isArray(o[i]))) {
                         //going on step down in the object tree!!
                         traverse(o[i],x[i],func);
                     }
                     func.apply(this,[x, i, x[i]]);
                 }
-            } else if (typeof(o) === "array") {
+            } else if (Array.isArray(o)) {
                 for (var i = 0; i < o.length; i++) {
                     // func.apply(this,[o, i,o[i]]);
-                    if (o[i] !== null && (typeof(o[i])=="object" || typeof(o[i])=="array")) {
+                    if (o[i] !== null && (typeof(o[i])=="object" || Array.isArray(o[i]))) {
                         //going on step down in the object tree!!
                         traverse(o[i], x[i], func);
                     }

--- a/package.json
+++ b/package.json
@@ -18,8 +18,5 @@
   "bugs": {
     "url": "https://github.com/chrisvxd/firebase-key-encode/issues"
   },
-  "homepage": "https://github.com/chrisvxd/firebase-key-encode#readme",
-  "dependencies": {
-    "lodash": "~4.16.2"
-  }
+  "homepage": "https://github.com/chrisvxd/firebase-key-encode#readme"
 }


### PR DESCRIPTION
Use Object.assign instead of lodash. You could also just `require("lodash.clone")` but `Object.assign()` is included in most browsers now and can be transpiled by babel (up to you if you want to include a babel build process for ES5 consumers of this library).

Also, `typeof(arr)` will always return `"object"` so I moved to `Array.isArray()`.